### PR TITLE
Remove dataFiles attribute from Gatekeeper API.

### DIFF
--- a/components/DatasetDetails/DataCard/DataExplorer.tsx
+++ b/components/DatasetDetails/DataCard/DataExplorer.tsx
@@ -14,15 +14,16 @@ export default function DataExplorer(props: Props) {
   // I added this to move the .dataset.data.dataFiles to the .current_version.files
   // if the version is empty. This will be used during the transition from Remove File upload
   // to Update data files to the Datamap platform data storage.
-  if (props.dataset?.data?.dataFiles?.length && props.dataset?.current_version?.files?.length <= 0) {
-    props.dataset.current_version.files = props.dataset?.data?.dataFiles
-      ?.map((item, idx) => (
-        {
-          id: String(idx),
-          name: item.path
-        } as GetDatasetDetailsVersionFileResponse
-      ))
-  }
+  // FIX: This code was commented because now datafiles come from version. This must be fixed.
+  // if (props.dataset?.data?.dataFiles?.length && props.dataset?.current_version?.files?.length <= 0) {
+  //   props.dataset.current_version.files = props.dataset?.data?.dataFiles
+  //     ?.map((item, idx) => (
+  //       {
+  //         id: String(idx),
+  //         name: item.path
+  //       } as GetDatasetDetailsVersionFileResponse
+  //     ))
+  // }
 
   // const [dataExplorerCollapsed, setDataExplorerCollapsed] = useState(false);
   const [loadingTable, setLoadingTable] = useState(false);

--- a/lib/__tests__/dataset.test.ts
+++ b/lib/__tests__/dataset.test.ts
@@ -27,7 +27,6 @@ const APIResponseFixture = {
         database: '',
         end_date: '1970-02-01T03:00:00.000Z',
         location: { location: 'Global' },
-        dataFiles: [[Object]],
         data_type: '',
         grid_type: '',
         reference: [],

--- a/lib/dataset.ts
+++ b/lib/dataset.ts
@@ -1,14 +1,10 @@
 
-import { CreateDatasetRequest, CreateDatasetResponse, DatasetCategoryFiltersResponse, GetDatasetDetailsResponse, GetDatasetsResponse, UpdateDatasetRequest, PublishDatasetVersionRequest, PublishDatasetVersionResponse } from "../types/BffAPI";
-import { DataFile, DatasetCreationRequest, DatasetInfo } from "../types/GatekeeperAPI";
+import { CreateDatasetRequest, CreateDatasetResponse, DatasetCategoryFiltersResponse, GetDatasetDetailsResponse, GetDatasetsResponse, PublishDatasetVersionRequest, PublishDatasetVersionResponse, UpdateDatasetRequest } from "../types/BffAPI";
+import { DatasetCreationRequest, DatasetInfo } from "../types/GatekeeperAPI";
 import { AppLocalContext } from "./appLocalContext";
 import axiosInstance, { buildHeaders } from "./rpc";
 
 function toDatasetInfo(datasetRequest: CreateDatasetRequest): DatasetInfo {
-    const dataFiles = datasetRequest?.urls?.map(
-        x => ({ path: x.url } as DataFile)
-    );
-
     return {
         id: "",
         name: datasetRequest.datasetTitle ?? datasetRequest?.title ?? "none",
@@ -38,8 +34,6 @@ function toDatasetInfo(datasetRequest: CreateDatasetRequest): DatasetInfo {
         contacts: null,
         colaborators: null,
         reference: [],
-        // TODO: deprecate dataFiles, we should always use the data files in version
-        dataFiles: dataFiles ?? [],
         additional_information: [],
         level: "",
         resolution: {

--- a/types/GatekeeperAPI.ts
+++ b/types/GatekeeperAPI.ts
@@ -24,13 +24,6 @@ export interface DatasetResponse {
     is_enabled: boolean
 }
 
-/**
- * A data file from a dataset.
- */
-export interface DataFile {
-    path: string,
-}
-
 export interface DatasetInfo {
     id: string,
     name: string,
@@ -59,7 +52,6 @@ export interface DatasetInfo {
         permission: string
     }[],
     reference: any[],
-    dataFiles: DataFile[],
     additional_information: any[],
     level: string,
     resolution: Resolution,


### PR DESCRIPTION
## 🤔 Problem
Deprecated code to clean up

## 🧐 Solution
Remove the unused attributed `DataFiles` from Gatekeeper API.