### PR TITLE
Pages and filter files in DataExplorer in memory

### DIFF
--- a/components/DatasetDetails/DataCard/DataExplorer.tsx
+++ b/components/DatasetDetails/DataCard/DataExplorer.tsx
@@ -1,4 +1,5 @@
 import Uppy from "@uppy/core";
+import { Form, Formik } from "formik";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from 'react';
 import { MaterialSymbol } from "react-material-symbols";
@@ -90,7 +91,8 @@ export default function DataExplorer(props: Props) {
             <DatasetFilesList
               dataset={props.dataset}
               datasetVersion={props.dataset.current_version}
-              handleSelectFile={handleSelectFile} />
+              handleSelectFile={handleSelectFile}
+              itemsPerPage={10} />
           </div>
           <hr />
           <div className="pt-4">
@@ -162,6 +164,7 @@ export default function DataExplorer(props: Props) {
                 dataset={props.dataset}
                 datasetVersion={stagingDatasetVersion}
                 handleSelectFile={handleSelectFile}
+                itemsPerPage={5}
                 onFileRemoved={(x) =>
                   setStagingDatasetVersion(
                     {
@@ -178,12 +181,17 @@ export default function DataExplorer(props: Props) {
             New uploads
           </h2>
           <div className="" >
-            <UppyUploader
-              datasetId={props.dataset.id}
-              userId={uploadAuth?.user?.id}
-              // TODO: Check if the token is working
-              userToken={uploadAuth?.token?.jwt}
-              onUppyStateCreated={onUppyStateCreated} />
+            {/* TODO: Config Formik correcly for this new form */}
+            <Formik initialValues={{ a: "test" }} onSubmit={() => { }}>
+              <Form>
+                <UppyUploader
+                  datasetId={props.dataset.id}
+                  userId={uploadAuth?.user?.id}
+                  // TODO: Check if the token is working
+                  userToken={uploadAuth?.token?.jwt}
+                  onUppyStateCreated={onUppyStateCreated} />
+              </Form>
+            </Formik>
           </div>
         </div>
       </Drawer>

--- a/components/DatasetDetails/DataCard/DatasetFilesList.tsx
+++ b/components/DatasetDetails/DataCard/DatasetFilesList.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MaterialSymbol } from 'react-material-symbols';
 import 'react-material-symbols/outlined'; // Place in your root app file. There are also `sharp` and `outlined` variants.
+import { BFFAPI } from "../../../gateways/BFFAPI";
 import { bytesToSize, fileNameResolution, isFolder } from "../../../lib/file";
 import { FileDownloadLinkRequest, FileDownloadLinkResponse, GetDatasetDetailsResponse, GetDatasetDetailsVersionFileResponse, GetDatasetDetailsVersionResponse } from "../../../types/BffAPI";
-import { BFFAPI } from "../../../gateways/BFFAPI";
 
 interface Props {
+    itemsPerPage: number;
     dataset: GetDatasetDetailsResponse,
     datasetVersion: GetDatasetDetailsVersionResponse
     handleSelectFile?(file: GetDatasetDetailsVersionFileResponse): void;
@@ -14,27 +15,121 @@ interface Props {
 
 export default function DatasetFilesList(props: Props) {
 
-    const [selectedFile, setSelectedFile] = useState(props.datasetVersion?.files?.[0]?.name ?? null);
+    const itemsPerPage = props.itemsPerPage;
+    const [currentFilesList, setCurrentFilesList] = useState(props.datasetVersion?.files)
+    const [nameFilter, setNameFilter] = useState("")
+    const [page, setPage] = useState(1);
 
-    function handleSelectFile(file: GetDatasetDetailsVersionFileResponse): void {
-        setSelectedFile(file.name);
-        props.handleSelectFile(file);
+    // TODO: file select is not useful without a file descriptor
+    // const [selectedFile, setSelectedFile] = useState(props.datasetVersion?.files?.[0]?.name ?? null);
+    // function handleSelectFile(file: GetDatasetDetailsVersionFileResponse): void {
+    //     setSelectedFile(file.name);
+    //     props.handleSelectFile(file);
+    // }
+
+    useEffect(() => {
+        setCurrentFilesList(props.datasetVersion?.files)
+        onTextSearchChange(nameFilter)
+    }, [props.datasetVersion?.files])
+
+
+    function getMaxPageNumber() {
+        return currentFilesList?.length / itemsPerPage;
+    }
+
+
+    function getPage() {
+        const fullList = currentFilesList?.sort((a, b) => {
+            return a.name.localeCompare(b.name)
+        })
+
+        const result = fullList.slice((page * itemsPerPage) - itemsPerPage, (page * itemsPerPage))
+        return result;
+    }
+
+    function onTextSearchChange(filterText: string) {
+        filterFiles(filterText)
+    }
+
+    function filterFiles(filterText: string) {
+        setNameFilter(filterText)
+        if (filterText == "") {
+            setCurrentFilesList(props.datasetVersion.files)
+        } else {
+            const filtered = props.datasetVersion.files.filter(x => x.name.includes(filterText))
+            setCurrentFilesList(filtered)
+        }
+        setPage(1)
+    }
+
+    function shouldPaginate() {
+        return props.datasetVersion?.files?.length > itemsPerPage;
     }
 
     return (
-        <ul className="list-none py-2 overflow-x-auto">
-            {props.datasetVersion?.files?.map((file, i) => (
-                <li className={`${selectedFile === file.name ? "bg-primary-200" : "hover:bg-primary-100"} text-sm text-primary-500 font-light whitespace-nowrap my-1`} key={i}
-                    onClick={() => handleSelectFile(file)}>
-                    <FileListRowItem
-                        dataset={props.dataset}
-                        datasetVersion={props.datasetVersion}
-                        file={file}
-                        onFileRemoved={props.onFileRemoved}
-                    />
-                </li>
-            ))}
-        </ul>
+        <div>
+            {shouldPaginate() &&
+                <div className="w-full pt-4">
+                    <input
+                        name="nameFilter"
+                        id="nameFilter"
+                        type="text"
+                        placeholder="Filter by name"
+                        value={nameFilter}
+                        onChange={(e) => onTextSearchChange(e.target.value)} />
+                </div>
+            }
+            <ul className="list-none py-2 overflow-x-auto">
+                {getPage().map((file, i) => (
+                    <li className="hover:bg-primary-100 text-sm text-primary-500 font-light whitespace-nowrap my-1" key={i}>
+                        <FileListRowItem
+                            dataset={props.dataset}
+                            datasetVersion={props.datasetVersion}
+                            file={file}
+                            onFileRemoved={props.onFileRemoved}
+                        />
+                    </li>
+                ))}
+                {getPage().length <= 0 &&
+                    <li className="border border-primary-200 bg-primary-100 p-8 text-center rounded">
+                        <h6>No Results Found</h6>
+                        <p className="text-xs">It looks like there are no files matching your search criteria.</p>
+                        <p className="text-xs">Try adjusting or clearing your filters to view more results.</p>
+                        <button
+                            className="btn-primary-outline btn-small"
+                            onClick={() => {
+                                setNameFilter("");
+                                filterFiles("")
+                            }}>
+                            Clear Filters
+                        </button>
+                    </li>
+                }
+                {shouldPaginate() &&
+                    <li>
+                        <div className="flex justify-end items-center space-x-4">
+                            <span className="text-xs">
+                                Total files: {props?.datasetVersion?.files?.length}
+                            </span>
+                            <button
+                                className="h-8 w-24 p-2 btn whitespace-nowrap text-xs align-middle flex flex-row justify-center items-center space-x-2 hover:border hover:border-primary-200 disabled:text-primary-400 disabled:hover:border-0"
+                                onClick={() => setPage(page - 1)}
+                                disabled={page <= 1}>
+                                <MaterialSymbol icon="chevron_left" size={22} grade={-25} weight={200} />
+                                <span>Previous</span>
+                            </button>
+                            <button
+                                className="h-8 w-24 p-2 btn whitespace-nowrap text-xs align-middle flex flex-row justify-center items-center space-x-2 hover:border hover:border-primary-200 disabled:text-primary-400 disabled:hover:border-0"
+                                onClick={() => setPage(page + 1)}
+                                disabled={page >= getMaxPageNumber()}>
+                                <span>Next</span>
+                                <MaterialSymbol icon="chevron_right" size={22} grade={-25} weight={200} />
+                            </button>
+                        </div>
+                    </li>
+                }
+            </ul>
+        </div>
     )
 }
 
@@ -58,8 +153,9 @@ function FileListRowItem(props: FileListRowItemProps) {
             <DownloadFileButton
                 dataset={props.dataset}
                 datasetVersion={props.datasetVersion}
-                file={props.file} />
-            <RemoveFileButton onFileRemoved={props.onFileRemoved} />
+                file={props.file}
+                show={!props.onFileRemoved} />
+            <RemoveFileButton file={props.file} onFileRemoved={props.onFileRemoved} />
         </div>
     )
 
@@ -80,7 +176,9 @@ function RemoveFileButton(props) {
     }
 
     return (
-        <button onClick={() => props.onFileRemoved(props.file)}>
+        <button
+            onClick={() => props.onFileRemoved(props.file)}
+        >
             <MaterialSymbol icon="close" grade={-25} size={22} weight={400} />
         </button>
     )
@@ -90,6 +188,7 @@ interface DownloadFileButtonProps {
     dataset: GetDatasetDetailsResponse,
     datasetVersion: GetDatasetDetailsVersionResponse,
     file: GetDatasetDetailsVersionFileResponse,
+    show?: boolean
 }
 
 function DownloadFileButton(props: DownloadFileButtonProps) {
@@ -97,8 +196,6 @@ function DownloadFileButton(props: DownloadFileButtonProps) {
     const [downloading, setDownloading] = useState(false)
 
     async function DownloadFile(fileName: string, urlLink: string) {
-        console.log("url", urlLink)
-
         const response = await fetch(urlLink);
         if (response.status !== 200) {
             console.log("Error fetching image");
@@ -132,6 +229,10 @@ function DownloadFileButton(props: DownloadFileButtonProps) {
             .finally(() => setDownloading(false));
 
 
+    }
+
+    if (!props.show) {
+        return null;
     }
 
     if (downloading) {

--- a/pages/app/datasets/new.tsx
+++ b/pages/app/datasets/new.tsx
@@ -83,7 +83,6 @@ export default function NewPage() {
 
   function handleSubmitForm(values: FormValues, actions: FormikHelpers<any>) {
     // Mapping datasetPrototyping.createDatasetResponseV2 top UpdateDatasetRequest
-    console.log(session?.user);
     datasetPrototyping.createDatasetResponseV2.data.authors = [{ name: session?.user?.name }]
     const datasetUpdateRequest = {
       id: datasetPrototyping.createDatasetResponseV2.id,


### PR DESCRIPTION
## 🤔 Problem
When a dataset has many files, the experience for users is not good.

## 🧐 Solution
Paginate and filter it on the client side to create a better experience.

## 🤨 Rationale
Filters and pagination allow a reasoning visualization of a small amount of files, but let the users know that we have many files available.

We decided to paginate on the client side for now because it's easier to do. But, ideally, the pagination should come from Gatekeeper API.

## 📷 Screenshots 
**Full list of files**
When we have more than 10 files, the pagination (prev and next buttons), total files counter, and text filter by name show up.
<img width="1120" alt="Screenshot 2024-10-05 at 19 34 57" src="https://github.com/user-attachments/assets/df7e629a-026c-4074-b524-9524acd1f2e9">

**New version files**
In the new version "previous file" we have the same mechanism, but the size of the page is limited to 5 files.
<img width="751" alt="Screenshot 2024-10-05 at 19 35 09" src="https://github.com/user-attachments/assets/636879a4-fb9f-4556-9ba2-af941da2d6bb">

**Filter that matches nothing**
When the filter doesn't match anything, an empty table message is shown to users to help them understand what happened and how to handle it.
<img width="749" alt="Screenshot 2024-10-05 at 19 37 07" src="https://github.com/user-attachments/assets/3fbb3482-c77f-469a-8152-d5fd90e0132b">

**Small files list**
If the amount of files is less than 10, we don't shown the filter, pagination, and total files counter.
<img width="590" alt="Screenshot 2024-10-05 at 19 38 44" src="https://github.com/user-attachments/assets/2bf7ef40-278d-4208-a891-6e2c4cce6cfe">
