### PR TITLE
Mobile layout home and login fixes

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,12 +12,12 @@ export function Footer(props: FooterProps) {
       className={`bg-secondary-900 h-fit ${props.marginTop ?? "mt-12"} `}
     >
       <div className="container mx-auto pt-24">
-        <div className="grid grid-rows-1 grid-flow-col gap-4">
+        <div className="grid grid-rows-1 md:grid-flow-col px-8 gap-4">
           <div className="row-span-2">
             <Link href="/">
-              <img src="/img/logo.svg" alt="DataMap" className="px-6 w-60 " />
+              <img src="/img/logo.svg" alt="DataMap" className="md:px-6 w-60 " />
             </Link>
-            <p className="px-12 py-8">
+            <p className="md:px-12 py-8">
               Have an account?{" "}
               <Link
                 href={{

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,11 +11,12 @@ interface Props {
 
 export default (props: Props) => {
   return (
-    <>
+    <div className="">
       <Head>
         <title>DataMap</title>
         <link rel="icon" href="/favicon.ico" />
         <meta charSet="utf-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
       </Head>
 
       <Navbar />
@@ -27,6 +28,6 @@ export default (props: Props) => {
         {props.children}
       </main>
       {!props.hideFooter && <Footer marginTop={props.footerPropsMarginTop} />}
-    </>
+    </div>
   );
 };

--- a/components/LoggedLayout.tsx
+++ b/components/LoggedLayout.tsx
@@ -37,6 +37,7 @@ export default (props: Props) => {
         <title>DataMap</title>
         <link rel="icon" href="/favicon.ico" />
         <meta charSet="utf-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
       </Head>
 
       <main className="flex flex-nowrap flex-row">

--- a/components/Navbar/MobileNavbar.tsx
+++ b/components/Navbar/MobileNavbar.tsx
@@ -57,9 +57,9 @@ export function HiddenNav(props) {
       <div
         className={`${
           isActive ? null : "hidden"
-        } md:hidden ml-8 border-b border-t border-primary-200 z-40 fixed top-16 w-full bg-primary-50 opacity-[.99]`}
+        } md:hidden fixed left-0 top-16 w-full border-b border-t border-primary-200 z-40 bg-primary-50 opacity-[.99]`}
       >
-        <ul className="flex flex-col p-4 ml-4">{props.children}</ul>
+        <ul className="flex flex-col py-4">{props.children}</ul>
       </div>
     </div>
   );

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { HiddenNav, MobileMenuItem as MobileNavbarItem } from "./MobileNavbar";
 import { ActionItemsNavBar } from "./ActionItemsNavBar";
+import { HiddenNav, MobileMenuItem as MobileNavbarItem } from "./MobileNavbar";
 
 interface Props {
   children?: React.ReactNode;
@@ -25,28 +25,10 @@ export function Navbar() {
             <img src="/img/logo.svg" alt="DataMap" className=" h-9" />
           </Link>
 
-          <nav className="hidden md:flex flex-row ml-10">
-            {/* <NavbarItem id="navbarItemSearch" href={ROUTE_PAGE_SEARCH}>
-              Search
-            </NavbarItem> */}
-            {/* <NavbarItem id="navbarItemTools" href="/tools">
-              Tools
-            </NavbarItem>
-            <NavbarItem id="navbarItemProject" href="/project">
-              Project
-            </NavbarItem> */}
-          </nav>
-
           <HiddenNav items={["Search", "Tools", "Support"]}>
-            {/* <MobileNavbarItem id="mobileNavbarItemSearch" href={ROUTE_PAGE_SEARCH}>
-              Search
-            </MobileNavbarItem> */}
-            {/* <MobileNavbarItem id="mobileNavbarItemTools" href="/tools">
-              Tools
+            <MobileNavbarItem id="mobileNavbarItemSign" href="/account/login">
+              Sign in
             </MobileNavbarItem>
-            <MobileNavbarItem id="mobileNavbarItemProject" href="/project">
-              Project
-            </MobileNavbarItem> */}
           </HiddenNav>
 
           <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">

--- a/pages/account/login/index.tsx
+++ b/pages/account/login/index.tsx
@@ -4,6 +4,7 @@ import { TabPanel } from "../../../components/DatasetDetails/TabPanel";
 import { Tabs } from "../../../components/DatasetDetails/Tabs";
 
 import { signIn } from "next-auth/react";
+import Head from "next/head";
 import { FormEventHandler, useState } from "react";
 import { ROUTE_PAGE_SEARCH } from "../../../contants/InternalRoutesConstants";
 
@@ -99,13 +100,19 @@ export default function LoginPage(props) {
 
   return (
     <div className="container mx-auto flex flex-col gap-16 mt-16">
-      <Link href="/" className="w-2/12 h-16 self-center">
+      <Head>
+        <title>DataMap</title>
+        <link rel="icon" href="/favicon.ico" />
+        <meta charSet="utf-8"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+      </Head>
+      <Link href="/" className="w-full md:w-2/12 h-16 self-center">
         <img className="w-full h-full" src="/img/logo.svg" />
       </Link>
 
 
       {props.error &&
-        <div className="flex w-4/12 self-center items-center p-4 mb-4 text-primary-900 border-t-4 border-error-300 bg-error-50" role="alert">
+        <div className="flex w-10/12 md:w-4/12 self-center items-center p-4 mb-4 text-primary-900 border-t-4 border-error-300 bg-error-50" role="alert">
           <svg className="flex-shrink-0 w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
             <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
           </svg>
@@ -119,15 +126,10 @@ export default function LoginPage(props) {
         </div>
       }
 
-      <div className="w-4/12 h-fit border border-primary-200 self-center rounded">
+      <div className="w-10/12 md:w-4/12 h-fit border border-primary-200 self-center rounded">
         <Tabs className="py-8" defaultSelectedIndex={defaultTabIndex}>
           <TabPanel title="Sign In">
             <div className="flex flex-col">
-              {/* <button
-                type="button"
-                className="btn-primary-outline self-center font-medium text-sm px-5 py-2.5 text-center inline-flex items-center mr-2 mb-2 cursor-pointer"
-                onClick={() => signIn()}
-              >Providers</button> */}
               <OrcidButton callbackUrl={props.callbackUrl}>Sign in with ORCID</OrcidButton>
               {process.env.NODE_ENV == "development" &&
                 <GithubButton callbackUrl={props.callbackUrl}>Sign in with GitHub</GithubButton>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import Layout from "../components/Layout";
 import { ROUTE_PAGE_SEARCH } from "../contants/InternalRoutesConstants";
-import { ResearcherProfile } from "../components/ResearcherProfile";
 
 function TextDecorationBolder(props) {
   return (
@@ -36,11 +35,11 @@ export default function HomePage(props) {
       <div className="special-background">
         <div className="container mx-auto flex flex-row flex-wrap pt-56 pb-24">
           <div className="w-full">
-            <h1 className="font-bold text-8xl text-center pb-8">
+            <h1 className="font-bold text-7xl md:text-8xl text-center pb-8">
               <TextDecorationBolder>DataMap</TextDecorationBolder>
             </h1>
 
-            <h1 className="font-normal text-7xl text-center pb-8">
+            <h1 className="font-normal text-6xl md:text-7xl text-center pb-8">
               Scientific data analysis, for everyone.
               <br />
             </h1>


### PR DESCRIPTION
## 🤔 Problem
Public web pages had a malformed layout for mobile devices, and was not possible to access login page using mobile.

## 🧐 Solution
Fix CSS for a responsive layout.

## 🤨 Rationale
Allow users to have quick access by mobile phones.

## 🧪 E2E test results
Run `npm run test` on https://github.com/ardc-brazil/datamap-e2e and print the results here

## 📷 Screenshots 
| Page  | before | after |
|-------|--------|-------|
| Home  |  ![localhost_3000_(iPhone SE)](https://github.com/user-attachments/assets/a5887621-67c0-4d8b-967c-a73d65c0b744)|  ![datamap pcs usp br_(iPhone SE)](https://github.com/user-attachments/assets/8cccaa46-d19e-489b-a412-16a88c0b5a28) |
| Login | ![localhost_3000_account_login(iPhone SE)](https://github.com/user-attachments/assets/a22c6b4c-9a71-4383-b731-6e5f13982a9c)       |   ![datamap pcs usp br_account_login(iPhone SE)](https://github.com/user-attachments/assets/e4af49ea-7601-4483-8c6c-380c50ffb7d6)    |





