### PR TITLE
Remove "register" button and tab

### DIFF
--- a/components/Navbar/ActionItemsNavBar.tsx
+++ b/components/Navbar/ActionItemsNavBar.tsx
@@ -16,18 +16,9 @@ export function ActionItemsNavBar() {
             pathname: "/account/login",
             query: { phase: "sign-in", tenancy: "datamap/production/data-amazon" },
           }}
-          className="btn-primary-outline mx-2"
+          className="btn-primary"
         >
           Sign in
-        </Link>
-
-        <Link
-          href={{
-            pathname: "/account/login",
-            query: { phase: "register", tenancy: "datamap/production/data-amazon" },
-          }}
-        >
-          <button className="btn-primary">Register</button>
         </Link>
       </>
     );

--- a/pages/account/login/index.tsx
+++ b/pages/account/login/index.tsx
@@ -90,9 +90,7 @@ function EmailButton(props) {
 }
 
 export default function LoginPage(props) {
-  const router = useRouter();
   function getSelectedTabIndex() {
-    if (router?.query?.phase == "register") return 1;
     return 0;
   }
 
@@ -151,36 +149,6 @@ export default function LoginPage(props) {
                   </div>
                 )
               }
-              <p className="text-primary-500 text-center mt-6 text-sm">
-                No Account? &nbsp;
-                <Link
-                  href={{
-                    pathname: "/account/login",
-                    query: { phase: "register", tenancy: "datamap/production/data-amazon" },
-                  }}
-                  className="text-sm text-primary-800 cursor-pointer"
-                >
-                  Create one here.
-                </Link>
-              </p>
-            </div>
-          </TabPanel>
-          <TabPanel title="Register">
-            <div className="flex flex-col">
-              <OrcidButton>Register with ORCID</OrcidButton>
-              <EmailButton>Register with E-mail</EmailButton>
-              <p className="text-primary-500 text-center mt-6 text-sm">
-                Have an account?&nbsp;
-                <Link
-                  href={{
-                    pathname: "/account/login",
-                    query: { phase: "sign-in", tenancy: "datamap/production/data-amazon" },
-                  }}
-                  className="text-sm text-primary-800 cursor-pointer"
-                >
-                  Sign in
-                </Link>
-              </p>
             </div>
           </TabPanel>
         </Tabs>


### PR DESCRIPTION
## 🤔 Problem
We are not using the "Register" button, only sign in.

## 🧐 Solution
Remove the register button.

## 🤨 Rationale
Users don't have to register before signing in.

## 🧪 E2E test results
Run `npm run test` on https://github.com/ardc-brazil/datamap-e2e and print the results here

```
➜  datamap-e2e git:(main) npx playwright test

Running 23 tests using 4 workers
[web-auth-setup] › auth.setup.ts:5:6 › authenticate
Test user authenticated: {
  id: 'f680730f-8c1a-40d5-a86e-2135ae41de54',
  name: 'Conrad Ward',
  email: 'Luther.Franecki67@local.datamap.com',
  roles: [],
  is_enabled: true,
  created_at: '2024-11-04T00:59:13.998808Z',
  updated_at: '2024-11-04T00:59:13.998808Z',
  providers: [
    {
      name: 'credentials',
      reference: 'Luther.Franecki67@local.datamap.com'
    }
  ],
  tenancies: []
}
Cookies generated and stored at: /Users/andre.maia/workspace/datamap-e2e/playwright-report/.auth/user.json
  23 passed (48.0s)

To open last HTML report run:

  npx playwright show-report
```
## 📷 Screenshots 
Home
<img width="971" alt="image" src="https://github.com/user-attachments/assets/6cca6d76-3f49-4861-bc76-dbfcf6468558">

Sign in page
<img width="625" alt="image" src="https://github.com/user-attachments/assets/0411869e-115c-4aa0-bd8d-54ba2ef6a0b9">
