### PR TITLE
Change dataset name validation

### DIFF
--- a/components/DatasetDetails/TabPanelSettings.tsx
+++ b/components/DatasetDetails/TabPanelSettings.tsx
@@ -13,10 +13,10 @@ export function TabPanelSettings(props: TabPanelProps) {
   const schema = Yup.object().shape({
     name: Yup.string()
       .min(3, 'Min 3 characteres')
-      .max(50, 'Max 50 characters')
+      .max(255, 'Max 255 characters')
       .required('Required'),
     institution: Yup.string()
-      .max(50, 'Too long. Max 80 chars')
+      .max(255, 'Too long. Max 255 chars')
   });
 
   function onSubmit(values, { setSubmitting }) {


### PR DESCRIPTION
## 🤔 Problem
Users need more chars for dataset title and institution.

## 🧐 Solution
Increase the number of chars from 50 to 255.

## 🤨 Rationale
The table allows until 256 chars.
